### PR TITLE
The BaseEntity is an abstract class now

### DIFF
--- a/sample/SampleEndpointApp/DomainModel/BaseEntity.cs
+++ b/sample/SampleEndpointApp/DomainModel/BaseEntity.cs
@@ -1,6 +1,6 @@
 ﻿namespace SampleEndpointApp.DomainModel
 {
-    public class BaseEntity
+    public abstract class BaseEntity
     {
         public int Id { get; set; }
     }


### PR DESCRIPTION
Following the [CleanArchitecture](https://github.com/ardalis/CleanArchitecture/blob/master/src/CleanArchitecture.SharedKernel/BaseEntity.cs) template, the `BaseEntity` is an abstract class now.