### PR TITLE
Improve Code Analyzer (#30).  Ignore static methods and constructors.

### DIFF
--- a/src/Ardalis.ApiEndpoints.CodeAnalyzers/EndpointHasExtraPublicMethodAnalyzer.cs
+++ b/src/Ardalis.ApiEndpoints.CodeAnalyzers/EndpointHasExtraPublicMethodAnalyzer.cs
@@ -46,9 +46,12 @@ namespace Ardalis.ApiEndpoints.CodeAnalyzers
                 // not a method declaration
                 if (null == methodSymbol) return;
 
-                // ignore constructors
-                if (methodSymbol.MethodKind == MethodKind.Constructor) return;
-               
+                // ignore everything except 'ordinary' methods (delegates, operators, etc)
+                if (methodSymbol.MethodKind != MethodKind.Ordinary) return;
+
+                // ignore statics
+                if (methodSymbol.IsStatic) return;
+
                 // isn't public
                 if (methodSymbol.DeclaredAccessibility != Accessibility.Public) return;
 
@@ -70,7 +73,10 @@ namespace Ardalis.ApiEndpoints.CodeAnalyzers
                         .ContainingType
                         .GetMembers()
                         .OfType<IMethodSymbol>()
-                        .Where(m => m.DeclaredAccessibility == Accessibility.Public)
+                        .Where(m => 
+                            !m.IsStatic &&
+                            m.MethodKind == MethodKind.Ordinary &&
+                            m.DeclaredAccessibility == Accessibility.Public)
                         .ToList();
 
                 // and sort the methods so the "most correct" is first
@@ -126,8 +132,8 @@ namespace Ardalis.ApiEndpoints.CodeAnalyzers
                     return 1;
                 }
 
-                // give precedence to whoever has the shorter method name
-                return x.Name.Length.CompareTo(y.Name.Length);
+                // give precedence to which ever came first - so always x
+                return -1;
             }
         }
     }

--- a/tests/Ardalis.ApiEndpoints.CodeAnalyzers.Test/EndpointHasPublicActionMethodTests.cs
+++ b/tests/Ardalis.ApiEndpoints.CodeAnalyzers.Test/EndpointHasPublicActionMethodTests.cs
@@ -30,6 +30,25 @@ namespace Ardalis.ApiEndpoints.CodeAnalyzers.Test
                 }
             }";
 
+        private const string ValidEndpointWithExtraStaticMethod = @"
+            using System;
+            using System.Threading.Tasks;
+            using Microsoft.AspNetCore.Mvc;
+            using Ardalis.ApiEndpoints;
+
+            namespace ApiEndpointsAnalyzersTest
+            {
+                public class TestEndpoint : BaseAsyncEndpoint<object, object>
+                {
+                    public override async Task<ActionResult<object>> HandleAsync([FromBody]object request)
+                    {
+                        throw new Exception();
+                    }
+
+                    public static void ExtraMethod(){}
+                }
+            }";
+
         private const string ValidEndpointWithPublicConstructor = @"
             using System;
             using System.Threading.Tasks;
@@ -57,6 +76,48 @@ namespace Ardalis.ApiEndpoints.CodeAnalyzers.Test
 
             namespace ApiEndpointsAnalyzersTest
             {
+                public class TestEndpoint : BaseAsyncEndpoint
+                {
+                    public TestEndpoint() { }
+
+                    public override async Task<ActionResult<object>> HandleAsync([FromBody]object request)
+                    {
+                        return base.FooBar();
+                    }
+                }
+            }";
+
+         private const string ValidEndpointUsingCustomBaseClass = @"
+            using System;
+            using System.Threading.Tasks;
+            using Microsoft.AspNetCore.Mvc;
+            using Ardalis.ApiEndpoints;
+
+            namespace ApiEndpointsAnalyzersTest
+            {
+                public abstract class CustomBase : BaseAsyncEndpoint
+                {
+                    public abstract Task<ActionResult<object>> HandleAsync([FromBody]object request);
+                }
+
+                public class TestEndpoint : CustomBase
+                {
+                    public override async Task<ActionResult<object>> HandleAsync([FromBody]object request)
+                    {
+                        return base.FooBar();
+                    }
+                }
+            }";
+
+         private const string ValidEndpointWithCustomBaseAsyncEndpointDefined = @"
+            using System;
+            using System.Threading.Tasks;
+            using Microsoft.AspNetCore.Mvc;
+            
+            namespace ApiEndpointsAnalyzersTest
+            {
+                public abstract class BaseAsyncEndpoint { }
+
                 public class TestEndpoint : BaseAsyncEndpoint
                 {
                     public async Task<ActionResult<object>> HandleAsync([FromBody]object request)
@@ -501,9 +562,12 @@ namespace Ardalis.ApiEndpoints.CodeAnalyzers.Test
         [DataTestMethod]
         [DataRow(""),
          DataRow(ValidEndpoint),
+         DataRow(ValidEndpointWithExtraStaticMethod),
          DataRow(ValidEndpointWithExtraNonPublicMethods),
          DataRow(ValidEndpointWithPublicConstructor),
-         DataRow(ValidEndpointUsingNonGenericBaseClass)]
+         DataRow(ValidEndpointUsingNonGenericBaseClass),
+         DataRow(ValidEndpointUsingCustomBaseClass),
+         DataRow(ValidEndpointWithCustomBaseAsyncEndpointDefined)]
         public void WhenTestCodeIsValidNoDiagnosticIsTriggered(string testCode)
         {
             VerifyCSharpDiagnostic(testCode);


### PR DESCRIPTION
Fixes bugs where the Code Analyzer would count **constructors** or **static** methods when evaluating if a class had too many public methods.  The analyzer now considers this class fully valid:

```csharp
public class Example : BaseAsyncEndpoint
{
    public Example(){}
    public static void Helper() {}

    public Task<ActionResult> HandleAsync() 
    { 
         return Task.FromResult<ActionResult>(Ok());
    }     
}
```

**NOTE:** I tested this manually and confirmed the bug (#30) was fixed, but could use a second pair of eyes to double check. 👀