### PR TITLE
Adding WithRequest that contains two inputs

### DIFF
--- a/src/Ardalis.ApiEndpoints/BaseAsyncEndpoint.cs
+++ b/src/Ardalis.ApiEndpoints/BaseAsyncEndpoint.cs
@@ -30,6 +30,27 @@ namespace Ardalis.ApiEndpoints
             }
         }
 
+        public static class WithRequest<TRequest1, TRequest2>
+        {
+            public abstract class WithResponse<TResponse> : BaseEndpointAsync
+            {
+                public abstract Task<ActionResult<TResponse>> HandleAsync(
+                    TRequest1 request1,
+                    TRequest2 request2,
+                    CancellationToken cancellationToken = default
+                );
+            }
+
+            public abstract class WithoutResponse : BaseEndpointAsync
+            {
+                public abstract Task<ActionResult> HandleAsync(
+                    TRequest1 request1,
+                    TRequest2 request2,
+                    CancellationToken cancellationToken = default
+                );
+            }
+        }
+
         public static class WithoutRequest
         {
             public abstract class WithResponse<TResponse> : BaseEndpointAsync


### PR DESCRIPTION
This PR adds in the ability to specify two request parameters for an endpoint so that it is possible to have a route parameter and a body. The case I'm specifically talking about is where you need to `POST/PUT/PATCH` to a url `/parents/123/children` to create a child object.

This addresses what is talked about in issue #42 I believe this is a very common pattern and will solve issues for many people.

And if nothing else would it not be nice to solve [42](https://en.wikipedia.org/wiki/Phrases_from_The_Hitchhiker%27s_Guide_to_the_Galaxy#Why_the_number_42?)!!!!