### PR TITLE
Add `WithOkResponse` to avoid wrapping response in `Ok()`

### DIFF
--- a/sample/SampleEndpointApp/AuthorEndpoints/Create.cs
+++ b/sample/SampleEndpointApp/AuthorEndpoints/Create.cs
@@ -10,7 +10,7 @@ namespace SampleEndpointApp.Authors
 {
     public class Create : BaseAsyncEndpoint
         .WithRequest<CreateAuthorCommand>
-        .WithResponse<CreateAuthorResult>
+        .WithOkResponse<CreateAuthorResult>
     {
         private readonly IAsyncRepository<Author> _repository;
         private readonly IMapper _mapper;
@@ -29,14 +29,14 @@ namespace SampleEndpointApp.Authors
             OperationId = "Author.Create",
             Tags = new[] { "AuthorEndpoint" })
         ]
-        public override async Task<ActionResult<CreateAuthorResult>> HandleAsync([FromBody]CreateAuthorCommand request, CancellationToken cancellationToken)
+        public override async Task<CreateAuthorResult> HandleAsync([FromBody]CreateAuthorCommand request, CancellationToken cancellationToken)
         {
             var author = new Author();
             _mapper.Map(request, author);
             await _repository.AddAsync(author, cancellationToken);
 
             var result = _mapper.Map<CreateAuthorResult>(author);
-            return Ok(result);
+            return result;
         }
     }
 }

--- a/sample/SampleEndpointApp/AuthorEndpoints/Get.cs
+++ b/sample/SampleEndpointApp/AuthorEndpoints/Get.cs
@@ -10,7 +10,7 @@ namespace SampleEndpointApp.Authors
 {
     public class Get : BaseAsyncEndpoint
         .WithRequest<int>
-        .WithResponse<AuthorResult>
+        .WithOkResponse<AuthorResult>
     {
         private readonly IAsyncRepository<Author> _repository;
         private readonly IMapper _mapper;
@@ -29,13 +29,13 @@ namespace SampleEndpointApp.Authors
 			OperationId = "Author.Get",
 			Tags = new[] { "AuthorEndpoint" })
 		]
-        public override async Task<ActionResult<AuthorResult>> HandleAsync(int id, CancellationToken cancellationToken)
+        public override async Task<AuthorResult> HandleAsync(int id, CancellationToken cancellationToken)
         {
             var author = await _repository.GetByIdAsync(id, cancellationToken);
 
             var result = _mapper.Map<AuthorResult>(author);
 
-            return Ok(result);
+            return result;
         }
     }
 }

--- a/sample/SampleEndpointApp/AuthorEndpoints/List.cs
+++ b/sample/SampleEndpointApp/AuthorEndpoints/List.cs
@@ -13,7 +13,7 @@ namespace SampleEndpointApp.Authors
 {
     public class List : BaseAsyncEndpoint
         .WithRequest<AuthorListRequest>
-        .WithResponse<IList<AuthorListResult>>
+        .WithOkResponse<IList<AuthorListResult>>
     {
         private readonly IAsyncRepository<Author> repository;
         private readonly IMapper mapper;
@@ -32,7 +32,7 @@ namespace SampleEndpointApp.Authors
             OperationId = "Author.List",
             Tags = new[] { "AuthorEndpoint" })
         ]
-        public override async Task<ActionResult<IList<AuthorListResult>>> HandleAsync(
+        public override async Task<IList<AuthorListResult>> HandleAsync(
 
             [FromQuery] AuthorListRequest request,
             CancellationToken cancellationToken = default)
@@ -46,9 +46,10 @@ namespace SampleEndpointApp.Authors
                 request.Page = 1;
             }
             var result = (await repository.ListAllAsync(request.PerPage, request.Page, cancellationToken))
-                .Select(i => mapper.Map<AuthorListResult>(i));
+                .Select(i => mapper.Map<AuthorListResult>(i))
+                .ToList();
 
-            return Ok(result);
+            return result;
         }
     }
 }

--- a/sample/SampleEndpointApp/AuthorEndpoints/Update.cs
+++ b/sample/SampleEndpointApp/AuthorEndpoints/Update.cs
@@ -10,7 +10,7 @@ namespace SampleEndpointApp.Authors
 {
     public class Update : BaseAsyncEndpoint
         .WithRequest<UpdateAuthorCommand>
-        .WithResponse<UpdatedAuthorResult>
+        .WithOkResponse<UpdatedAuthorResult>
     {
         private readonly IAsyncRepository<Author> _repository;
         private readonly IMapper _mapper;
@@ -29,14 +29,14 @@ namespace SampleEndpointApp.Authors
 			OperationId = "Author.Update",
 			Tags = new[] { "AuthorEndpoint" })
 		]
-        public override async Task<ActionResult<UpdatedAuthorResult>> HandleAsync([FromBody]UpdateAuthorCommand request, CancellationToken cancellationToken)
+        public override async Task<UpdatedAuthorResult> HandleAsync([FromBody]UpdateAuthorCommand request, CancellationToken cancellationToken)
         {
             var author = await _repository.GetByIdAsync(request.Id, cancellationToken);
             _mapper.Map(request, author);
             await _repository.UpdateAsync(author, cancellationToken);
 
             var result = _mapper.Map<UpdatedAuthorResult>(author);
-            return Ok(result);
+            return result;
         }
     }
 }

--- a/src/Ardalis.ApiEndpoints/BaseAsyncEndpoint.cs
+++ b/src/Ardalis.ApiEndpoints/BaseAsyncEndpoint.cs
@@ -21,6 +21,14 @@ namespace Ardalis.ApiEndpoints
                 );
             }
 
+            public abstract class WithOkResponse<TResponse> : BaseEndpointAsync
+            {
+                public abstract Task<TResponse> HandleAsync(
+                    TRequest request,
+                    CancellationToken cancellationToken = default
+                );
+            }
+
             public abstract class WithoutResponse : BaseEndpointAsync
             {
                 public abstract Task<ActionResult> HandleAsync(
@@ -35,6 +43,13 @@ namespace Ardalis.ApiEndpoints
             public abstract class WithResponse<TResponse> : BaseEndpointAsync
             {
                 public abstract Task<ActionResult<TResponse>> HandleAsync(
+                    CancellationToken cancellationToken = default
+                );
+            }
+
+            public abstract class WithOkResponse<TResponse> : BaseEndpointAsync
+            {
+                public abstract Task<TResponse> HandleAsync(
                     CancellationToken cancellationToken = default
                 );
             }

--- a/src/Ardalis.ApiEndpoints/BaseEndpoint.cs
+++ b/src/Ardalis.ApiEndpoints/BaseEndpoint.cs
@@ -16,6 +16,11 @@ namespace Ardalis.ApiEndpoints
                 public abstract ActionResult<TResponse> Handle(TRequest request);
             }
 
+            public abstract class WithOkResponse<TResponse> : BaseEndpointSync
+            {
+                public abstract TResponse Handle(TRequest request);
+            }
+
             public abstract class WithoutResponse : BaseEndpointSync
             {
                 public abstract ActionResult Handle(TRequest request);
@@ -27,6 +32,11 @@ namespace Ardalis.ApiEndpoints
             public abstract class WithResponse<TResponse> : BaseEndpointSync
             {
                 public abstract ActionResult<TResponse> Handle();
+            }
+
+            public abstract class WithOkResponse<TResponse> : BaseEndpointSync
+            {
+                public abstract TResponse Handle();
             }
 
             public abstract class WithoutResponse : BaseEndpointSync


### PR DESCRIPTION
## Motivation

In Asp.Net Core if action only produces `Ok` responses, return type can be `T` instead of `ActionResult<T>`.

## What was done

Added `WithOkResponse` overloads that allow to avoid boilerplate of wrapping result in `Ok`. They use vanilla Asp.Net Core, no custom logic.