### PR TITLE
[v4] 3. Add two new `WithResult` methods and renamed old ones

### DIFF
--- a/sample/Sample.FunctionalTests/AuthorEndpoints/CreateEndpoint.cs
+++ b/sample/Sample.FunctionalTests/AuthorEndpoints/CreateEndpoint.cs
@@ -1,14 +1,13 @@
-﻿using Newtonsoft.Json;
-using SampleEndpointApp;
-using SampleEndpointApp.Authors;
-using SampleEndpointApp.DataAccess;
-using SampleEndpointApp.DomainModel;
-using System;
+﻿using System;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using SampleEndpointApp;
+using SampleEndpointApp.DataAccess;
+using SampleEndpointApp.Endpoints.Authors;
 using Xunit;
 
 namespace Sample.FunctionalTests.AuthorEndpoints

--- a/sample/Sample.FunctionalTests/AuthorEndpoints/DeleteEndpoint.cs
+++ b/sample/Sample.FunctionalTests/AuthorEndpoints/DeleteEndpoint.cs
@@ -1,15 +1,13 @@
-﻿using Newtonsoft.Json;
-using SampleEndpointApp;
-using SampleEndpointApp.Authors;
-using SampleEndpointApp.DataAccess;
-using SampleEndpointApp.DomainModel;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using SampleEndpointApp;
+using SampleEndpointApp.DomainModel;
+using SampleEndpointApp.Endpoints.Authors;
 using Xunit;
 
 namespace Sample.FunctionalTests.AuthorEndpoints

--- a/sample/Sample.FunctionalTests/AuthorEndpoints/UpdateEndpoint.cs
+++ b/sample/Sample.FunctionalTests/AuthorEndpoints/UpdateEndpoint.cs
@@ -1,14 +1,13 @@
-using Newtonsoft.Json;
-using SampleEndpointApp;
-using SampleEndpointApp.Authors;
-using SampleEndpointApp.DataAccess;
-using SampleEndpointApp.DomainModel;
-using System;
+﻿using System;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using SampleEndpointApp;
+using SampleEndpointApp.DataAccess;
+using SampleEndpointApp.Endpoints.Authors;
 using Xunit;
 
 namespace Sample.FunctionalTests.AuthorEndpoints

--- a/sample/Sample.FunctionalTests/Sample.FunctionalTests.csproj
+++ b/sample/Sample.FunctionalTests/Sample.FunctionalTests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />
-    <PackageReference Include="coverlet.collector" Version="3.0.3" PrivateAssets="all" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/SampleEndpointApp/AutoMapping.cs
+++ b/sample/SampleEndpointApp/AutoMapping.cs
@@ -1,6 +1,6 @@
 ﻿using AutoMapper;
-using SampleEndpointApp.Authors;
 using SampleEndpointApp.DomainModel;
+using SampleEndpointApp.Endpoints.Authors;
 
 namespace SampleEndpointApp
 {

--- a/sample/SampleEndpointApp/Endpoints/Authors/Create.CreateAuthorCommand.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Create.CreateAuthorCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace SampleEndpointApp.Authors
+namespace SampleEndpointApp.Endpoints.Authors
 {
     public class CreateAuthorCommand
     {

--- a/sample/SampleEndpointApp/Endpoints/Authors/Create.CreateAuthorResult.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Create.CreateAuthorResult.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace SampleEndpointApp.Authors
+namespace SampleEndpointApp.Endpoints.Authors
 {
     public class CreateAuthorResult : CreateAuthorCommand
     {

--- a/sample/SampleEndpointApp/Endpoints/Authors/Create.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Create.cs
@@ -9,7 +9,7 @@ namespace SampleEndpointApp.Endpoints.Authors
 {
     public class Create : EndpointBaseAsync
         .WithRequest<CreateAuthorCommand>
-        .WithResult<CreateAuthorResult>
+        .WithActionResult
     {
         private readonly IAsyncRepository<Author> _repository;
         private readonly IMapper _mapper;
@@ -25,14 +25,14 @@ namespace SampleEndpointApp.Endpoints.Authors
         /// Creates a new Author
         /// </summary>
         [HttpPost(CreateAuthorCommand.ROUTE)]
-        public override async Task<CreateAuthorResult> HandleAsync([FromBody]CreateAuthorCommand request, CancellationToken cancellationToken)
+        public override async Task<ActionResult> HandleAsync([FromBody] CreateAuthorCommand request, CancellationToken cancellationToken)
         {
             var author = new Author();
             _mapper.Map(request, author);
             await _repository.AddAsync(author, cancellationToken);
 
             var result = _mapper.Map<CreateAuthorResult>(author);
-            return result;
+            return CreatedAtRoute("Authors.Get", new { id = result.Id }, result);
         }
     }
 }

--- a/sample/SampleEndpointApp/Endpoints/Authors/Create.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Create.cs
@@ -9,7 +9,7 @@ namespace SampleEndpointApp.Authors
 {
     public class Create : EndpointBaseAsync
         .WithRequest<CreateAuthorCommand>
-        .WithResponse<CreateAuthorResult>
+        .WithActionResult<CreateAuthorResult>
     {
         private readonly IAsyncRepository<Author> _repository;
         private readonly IMapper _mapper;

--- a/sample/SampleEndpointApp/Endpoints/Authors/Create.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Create.cs
@@ -5,7 +5,7 @@ using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
 using SampleEndpointApp.DomainModel;
 
-namespace SampleEndpointApp.Authors
+namespace SampleEndpointApp.Endpoints.Authors
 {
     public class Create : EndpointBaseAsync
         .WithRequest<CreateAuthorCommand>

--- a/sample/SampleEndpointApp/Endpoints/Authors/Create.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Create.cs
@@ -9,7 +9,7 @@ namespace SampleEndpointApp.Endpoints.Authors
 {
     public class Create : EndpointBaseAsync
         .WithRequest<CreateAuthorCommand>
-        .WithActionResult<CreateAuthorResult>
+        .WithResult<CreateAuthorResult>
     {
         private readonly IAsyncRepository<Author> _repository;
         private readonly IMapper _mapper;
@@ -25,14 +25,14 @@ namespace SampleEndpointApp.Endpoints.Authors
         /// Creates a new Author
         /// </summary>
         [HttpPost(CreateAuthorCommand.ROUTE)]
-        public override async Task<ActionResult<CreateAuthorResult>> HandleAsync([FromBody]CreateAuthorCommand request, CancellationToken cancellationToken)
+        public override async Task<CreateAuthorResult> HandleAsync([FromBody]CreateAuthorCommand request, CancellationToken cancellationToken)
         {
             var author = new Author();
             _mapper.Map(request, author);
             await _repository.AddAsync(author, cancellationToken);
 
             var result = _mapper.Map<CreateAuthorResult>(author);
-            return Ok(result);
+            return result;
         }
     }
 }

--- a/sample/SampleEndpointApp/Endpoints/Authors/Delete.DeleteAuthorRequest.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Delete.DeleteAuthorRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace SampleEndpointApp.Authors
+﻿namespace SampleEndpointApp.Endpoints.Authors
 {
     public class DeleteAuthorRequest
     {

--- a/sample/SampleEndpointApp/Endpoints/Authors/Delete.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Delete.cs
@@ -4,7 +4,7 @@ using Ardalis.ApiEndpoints;
 using Microsoft.AspNetCore.Mvc;
 using SampleEndpointApp.DomainModel;
 
-namespace SampleEndpointApp.Authors
+namespace SampleEndpointApp.Endpoints.Authors
 {
     public class Delete : EndpointBaseAsync
         .WithRequest<DeleteAuthorRequest>

--- a/sample/SampleEndpointApp/Endpoints/Authors/Delete.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Delete.cs
@@ -8,7 +8,7 @@ namespace SampleEndpointApp.Authors
 {
     public class Delete : EndpointBaseAsync
         .WithRequest<DeleteAuthorRequest>
-        .WithoutResponse
+        .WithActionResult
     {
         private readonly IAsyncRepository<Author> _repository;
 

--- a/sample/SampleEndpointApp/Endpoints/Authors/Get.AuthorResult.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Get.AuthorResult.cs
@@ -1,4 +1,4 @@
-﻿namespace SampleEndpointApp.Authors
+﻿namespace SampleEndpointApp.Endpoints.Authors
 {
     public class AuthorResult
     {

--- a/sample/SampleEndpointApp/Endpoints/Authors/Get.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Get.cs
@@ -5,7 +5,7 @@ using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
 using SampleEndpointApp.DomainModel;
 
-namespace SampleEndpointApp.Authors
+namespace SampleEndpointApp.Endpoints.Authors
 {
     public class Get : EndpointBaseAsync
         .WithRequest<int>

--- a/sample/SampleEndpointApp/Endpoints/Authors/Get.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Get.cs
@@ -9,7 +9,7 @@ namespace SampleEndpointApp.Authors
 {
     public class Get : EndpointBaseAsync
         .WithRequest<int>
-        .WithResponse<AuthorResult>
+        .WithActionResult<AuthorResult>
     {
         private readonly IAsyncRepository<Author> _repository;
         private readonly IMapper _mapper;

--- a/sample/SampleEndpointApp/Endpoints/Authors/Get.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Get.cs
@@ -24,7 +24,7 @@ namespace SampleEndpointApp.Endpoints.Authors
         /// <summary>
         /// Get a specific Author
         /// </summary>
-        [HttpGet("/authors/{id}")]
+        [HttpGet("/authors/{id}", Name = "Authors.Get")]
         public override async Task<AuthorResult> HandleAsync(int id, CancellationToken cancellationToken)
         {
             var author = await _repository.GetByIdAsync(id, cancellationToken);

--- a/sample/SampleEndpointApp/Endpoints/Authors/Get.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Get.cs
@@ -9,7 +9,7 @@ namespace SampleEndpointApp.Endpoints.Authors
 {
     public class Get : EndpointBaseAsync
         .WithRequest<int>
-        .WithActionResult<AuthorResult>
+        .WithResult<AuthorResult>
     {
         private readonly IAsyncRepository<Author> _repository;
         private readonly IMapper _mapper;
@@ -25,13 +25,13 @@ namespace SampleEndpointApp.Endpoints.Authors
         /// Get a specific Author
         /// </summary>
         [HttpGet("/authors/{id}")]
-        public override async Task<ActionResult<AuthorResult>> HandleAsync(int id, CancellationToken cancellationToken)
+        public override async Task<AuthorResult> HandleAsync(int id, CancellationToken cancellationToken)
         {
             var author = await _repository.GetByIdAsync(id, cancellationToken);
 
             var result = _mapper.Map<AuthorResult>(author);
 
-            return Ok(result);
+            return result;
         }
     }
 }

--- a/sample/SampleEndpointApp/Endpoints/Authors/List.AuthorListRequest.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/List.AuthorListRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace SampleEndpointApp.Authors
+﻿namespace SampleEndpointApp.Endpoints.Authors
 {
     public class AuthorListRequest
     {

--- a/sample/SampleEndpointApp/Endpoints/Authors/List.AuthorListResult.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/List.AuthorListResult.cs
@@ -1,4 +1,4 @@
-﻿namespace SampleEndpointApp.Authors
+﻿namespace SampleEndpointApp.Endpoints.Authors
 {
     public class AuthorListResult
     {

--- a/sample/SampleEndpointApp/Endpoints/Authors/List.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/List.cs
@@ -11,7 +11,7 @@ namespace SampleEndpointApp.Authors
 {
     public class List : EndpointBaseAsync
         .WithRequest<AuthorListRequest>
-        .WithResponse<IList<AuthorListResult>>
+        .WithActionResult<IList<AuthorListResult>>
     {
         private readonly IAsyncRepository<Author> repository;
         private readonly IMapper mapper;

--- a/sample/SampleEndpointApp/Endpoints/Authors/List.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/List.cs
@@ -7,7 +7,7 @@ using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
 using SampleEndpointApp.DomainModel;
 
-namespace SampleEndpointApp.Authors
+namespace SampleEndpointApp.Endpoints.Authors
 {
     public class List : EndpointBaseAsync
         .WithRequest<AuthorListRequest>

--- a/sample/SampleEndpointApp/Endpoints/Authors/List.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/List.cs
@@ -11,7 +11,7 @@ namespace SampleEndpointApp.Endpoints.Authors
 {
     public class List : EndpointBaseAsync
         .WithRequest<AuthorListRequest>
-        .WithActionResult<IList<AuthorListResult>>
+        .WithResult<IEnumerable<AuthorListResult>>
     {
         private readonly IAsyncRepository<Author> repository;
         private readonly IMapper mapper;
@@ -28,8 +28,7 @@ namespace SampleEndpointApp.Endpoints.Authors
         /// List all Authors
         /// </summary>
         [HttpGet("/authors")]
-        public override async Task<ActionResult<IList<AuthorListResult>>> HandleAsync(
-
+        public override async Task<IEnumerable<AuthorListResult>> HandleAsync(
             [FromQuery] AuthorListRequest request,
             CancellationToken cancellationToken = default)
         {
@@ -44,7 +43,7 @@ namespace SampleEndpointApp.Endpoints.Authors
             var result = (await repository.ListAllAsync(request.PerPage, request.Page, cancellationToken))
                 .Select(i => mapper.Map<AuthorListResult>(i));
 
-            return Ok(result);
+            return result;
         }
     }
 }

--- a/sample/SampleEndpointApp/Endpoints/Authors/ListJsonFile.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/ListJsonFile.cs
@@ -6,7 +6,7 @@ using Ardalis.ApiEndpoints;
 using Microsoft.AspNetCore.Mvc;
 using SampleEndpointApp.DomainModel;
 
-namespace SampleEndpointApp.Authors
+namespace SampleEndpointApp.Endpoints.Authors
 {
     public class ListJsonFile : EndpointBaseAsync
         .WithoutRequest

--- a/sample/SampleEndpointApp/Endpoints/Authors/ListJsonFile.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/ListJsonFile.cs
@@ -10,7 +10,7 @@ namespace SampleEndpointApp.Authors
 {
     public class ListJsonFile : EndpointBaseAsync
         .WithoutRequest
-        .WithoutResponse // TODO: Maybe have a custom file response?
+        .WithActionResult // TODO: Maybe have a custom file response?
     {
         private readonly IAsyncRepository<Author> repository;
 

--- a/sample/SampleEndpointApp/Endpoints/Authors/ListJsonFile.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/ListJsonFile.cs
@@ -10,7 +10,7 @@ namespace SampleEndpointApp.Endpoints.Authors
 {
     public class ListJsonFile : EndpointBaseAsync
         .WithoutRequest
-        .WithActionResult // TODO: Maybe have a custom file response?
+        .WithActionResult
     {
         private readonly IAsyncRepository<Author> repository;
 
@@ -28,7 +28,7 @@ namespace SampleEndpointApp.Endpoints.Authors
         {
             var result = (await repository.ListAllAsync(cancellationToken)).ToList();
 
-             var streamData = JsonSerializer.SerializeToUtf8Bytes(result);
+            var streamData = JsonSerializer.SerializeToUtf8Bytes(result);
             return File(streamData, "text/json", "authors.json");
         }
     }

--- a/sample/SampleEndpointApp/Endpoints/Authors/Update.UpdateAuthorCommand.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Update.UpdateAuthorCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace SampleEndpointApp.Authors
+namespace SampleEndpointApp.Endpoints.Authors
 {
     public class UpdateAuthorCommand
     {

--- a/sample/SampleEndpointApp/Endpoints/Authors/Update.UpdatedAuthorResult.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Update.UpdatedAuthorResult.cs
@@ -1,4 +1,4 @@
-﻿namespace SampleEndpointApp.Authors
+﻿namespace SampleEndpointApp.Endpoints.Authors
 {
     public class UpdatedAuthorResult
     {

--- a/sample/SampleEndpointApp/Endpoints/Authors/Update.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Update.cs
@@ -9,7 +9,7 @@ namespace SampleEndpointApp.Authors
 {
     public class Update : EndpointBaseAsync
         .WithRequest<UpdateAuthorCommand>
-        .WithResponse<UpdatedAuthorResult>
+        .WithActionResult<UpdatedAuthorResult>
     {
         private readonly IAsyncRepository<Author> _repository;
         private readonly IMapper _mapper;

--- a/sample/SampleEndpointApp/Endpoints/Authors/Update.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Update.cs
@@ -9,7 +9,7 @@ namespace SampleEndpointApp.Endpoints.Authors
 {
     public class Update : EndpointBaseAsync
         .WithRequest<UpdateAuthorCommand>
-        .WithActionResult<UpdatedAuthorResult>
+        .WithResult<UpdatedAuthorResult>
     {
         private readonly IAsyncRepository<Author> _repository;
         private readonly IMapper _mapper;
@@ -25,14 +25,14 @@ namespace SampleEndpointApp.Endpoints.Authors
         /// Updates an existing Author
         /// </summary>
         [HttpPut("/authors")]
-        public override async Task<ActionResult<UpdatedAuthorResult>> HandleAsync([FromBody]UpdateAuthorCommand request, CancellationToken cancellationToken)
+        public override async Task<UpdatedAuthorResult> HandleAsync([FromBody]UpdateAuthorCommand request, CancellationToken cancellationToken)
         {
             var author = await _repository.GetByIdAsync(request.Id, cancellationToken);
             _mapper.Map(request, author);
             await _repository.UpdateAsync(author, cancellationToken);
 
             var result = _mapper.Map<UpdatedAuthorResult>(author);
-            return Ok(result);
+            return result;
         }
     }
 }

--- a/sample/SampleEndpointApp/Endpoints/Authors/Update.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Update.cs
@@ -5,7 +5,7 @@ using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
 using SampleEndpointApp.DomainModel;
 
-namespace SampleEndpointApp.Authors
+namespace SampleEndpointApp.Endpoints.Authors
 {
     public class Update : EndpointBaseAsync
         .WithRequest<UpdateAuthorCommand>

--- a/sample/SampleEndpointApp/Endpoints/Authors/Update.cs
+++ b/sample/SampleEndpointApp/Endpoints/Authors/Update.cs
@@ -25,7 +25,7 @@ namespace SampleEndpointApp.Endpoints.Authors
         /// Updates an existing Author
         /// </summary>
         [HttpPut("/authors")]
-        public override async Task<UpdatedAuthorResult> HandleAsync([FromBody]UpdateAuthorCommand request, CancellationToken cancellationToken)
+        public override async Task<UpdatedAuthorResult> HandleAsync([FromBody] UpdateAuthorCommand request, CancellationToken cancellationToken)
         {
             var author = await _repository.GetByIdAsync(request.Id, cancellationToken);
             _mapper.Map(request, author);

--- a/sample/SampleEndpointApp/SampleEndpointApp.csproj
+++ b/sample/SampleEndpointApp/SampleEndpointApp.csproj
@@ -13,13 +13,13 @@
     <PackageReference Include="Ardalis.EFCore.Extensions" Version="1.1.0" />
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" PrivateAssets="all" Version="5.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" PrivateAssets="all" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.9" />
     <PackageReference Include="SQLite" Version="3.13.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.5" />
     
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ardalis.ApiEndpoints.CodeAnalyzers/Ardalis.ApiEndpoints.CodeAnalyzers.csproj
+++ b/src/Ardalis.ApiEndpoints.CodeAnalyzers/Ardalis.ApiEndpoints.CodeAnalyzers.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ardalis.ApiEndpoints.CodeAnalyzers/Ardalis.ApiEndpoints.CodeAnalyzers.csproj
+++ b/src/Ardalis.ApiEndpoints.CodeAnalyzers/Ardalis.ApiEndpoints.CodeAnalyzers.csproj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <PackageId>Ardalis.ApiEndpoints.CodeAnalyzers</PackageId>
-    <Version>1.1.1</Version>
+    <Version>4.0.0-pre1</Version>
     <Authors>Steve Smith (@ardalis), Philip Pittle (@ppittle)</Authors>
     <PackageIconUrl>https://user-images.githubusercontent.com/782127/33497760-facf6550-d69c-11e7-94e4-b3856da259a9.png</PackageIconUrl>
     <Company>Ardalis.com</Company>
@@ -17,7 +17,7 @@
     <RepositoryUrl>https://github.com/ardalis/ApiEndpoints</RepositoryUrl>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <PackageTags>api endpoints code analyzers roslyn</PackageTags>
-    <PackageReleaseNotes>Fixes bug affecting constructors and static methods.</PackageReleaseNotes>
+    <PackageReleaseNotes>TODO</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Ardalis.ApiEndpoints/Ardalis.ApiEndpoints.csproj
+++ b/src/Ardalis.ApiEndpoints/Ardalis.ApiEndpoints.csproj
@@ -11,8 +11,8 @@
     <Summary>Controllers promote creating bloated classes that lack cohesion. This project provides a simpler alternative that follows SOLID principles. An alternative to Controllers for ASP.NET Core API Endpoints.</Summary>
     <RepositoryUrl>https://github.com/ardalis/ApiEndpoints</RepositoryUrl>
     <PackageTags>aspnet asp.net aspnetcore asp.net core api web api rest endpoint controller</PackageTags>
-    <PackageReleaseNotes>Updated package dependencies to latest; updated sample app and test projects to .NET 5</PackageReleaseNotes>
-    <Version>3.1.0</Version>
+    <PackageReleaseNotes>TODO</PackageReleaseNotes>
+    <Version>4.0.0-pre1</Version>
     <AssemblyName>Ardalis.ApiEndpoints</AssemblyName>
     <PackageIconUrl>https://user-images.githubusercontent.com/782127/33497760-facf6550-d69c-11e7-94e4-b3856da259a9.png</PackageIconUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ardalis.ApiEndpoints/FluentGenerics/EndpointBaseAsync.cs
+++ b/src/Ardalis.ApiEndpoints/FluentGenerics/EndpointBaseAsync.cs
@@ -11,6 +11,22 @@ namespace Ardalis.ApiEndpoints
     {
         public static class WithRequest<TRequest>
         {
+            public abstract class WithResult<TResponse> : EndpointBase
+            {
+                public abstract Task<TResponse> HandleAsync(
+                    TRequest request,
+                    CancellationToken cancellationToken = default
+                );
+            }
+
+            public abstract class WithoutResult : EndpointBase
+            {
+                public abstract Task HandleAsync(
+                    TRequest request,
+                    CancellationToken cancellationToken = default
+                );
+            }
+
             public abstract class WithActionResult<TResponse> : EndpointBase
             {
                 public abstract Task<ActionResult<TResponse>> HandleAsync(
@@ -30,6 +46,20 @@ namespace Ardalis.ApiEndpoints
 
         public static class WithoutRequest
         {
+            public abstract class WithResult<TResponse> : EndpointBase
+            {
+                public abstract Task<TResponse> HandleAsync(
+                    CancellationToken cancellationToken = default
+                );
+            }
+
+            public abstract class WithoutResult : EndpointBase
+            {
+                public abstract Task HandleAsync(
+                    CancellationToken cancellationToken = default
+                );
+            }
+
             public abstract class WithActionResult<TResponse> : EndpointBase
             {
                 public abstract Task<ActionResult<TResponse>> HandleAsync(

--- a/src/Ardalis.ApiEndpoints/FluentGenerics/EndpointBaseAsync.cs
+++ b/src/Ardalis.ApiEndpoints/FluentGenerics/EndpointBaseAsync.cs
@@ -11,7 +11,7 @@ namespace Ardalis.ApiEndpoints
     {
         public static class WithRequest<TRequest>
         {
-            public abstract class WithResponse<TResponse> : EndpointBase
+            public abstract class WithActionResult<TResponse> : EndpointBase
             {
                 public abstract Task<ActionResult<TResponse>> HandleAsync(
                     TRequest request,
@@ -19,7 +19,7 @@ namespace Ardalis.ApiEndpoints
                 );
             }
 
-            public abstract class WithoutResponse : EndpointBase
+            public abstract class WithActionResult : EndpointBase
             {
                 public abstract Task<ActionResult> HandleAsync(
                     TRequest request,
@@ -30,14 +30,14 @@ namespace Ardalis.ApiEndpoints
 
         public static class WithoutRequest
         {
-            public abstract class WithResponse<TResponse> : EndpointBase
+            public abstract class WithActionResult<TResponse> : EndpointBase
             {
                 public abstract Task<ActionResult<TResponse>> HandleAsync(
                     CancellationToken cancellationToken = default
                 );
             }
 
-            public abstract class WithoutResponse : EndpointBase
+            public abstract class WithActionResult : EndpointBase
             {
                 public abstract Task<ActionResult> HandleAsync(
                     CancellationToken cancellationToken = default

--- a/src/Ardalis.ApiEndpoints/FluentGenerics/EndpointBaseSync.cs
+++ b/src/Ardalis.ApiEndpoints/FluentGenerics/EndpointBaseSync.cs
@@ -9,6 +9,16 @@ namespace Ardalis.ApiEndpoints
     {
         public static class WithRequest<TRequest>
         {
+            public abstract class WithResult<TResponse> : EndpointBase
+            {
+                public abstract TResponse Handle(TRequest request);
+            }
+
+            public abstract class WithoutResult: EndpointBase
+            {
+                public abstract void Handle(TRequest request);
+            }
+
             public abstract class WithActionResult<TResponse> : EndpointBase
             {
                 public abstract ActionResult<TResponse> Handle(TRequest request);
@@ -22,6 +32,16 @@ namespace Ardalis.ApiEndpoints
 
         public static class WithoutRequest
         {
+            public abstract class WithResult<TResponse> : EndpointBase
+            {
+                public abstract TResponse Handle();
+            }
+
+            public abstract class WithoutResult : EndpointBase
+            {
+                public abstract void Handle();
+            }
+
             public abstract class WithActionResult<TResponse> : EndpointBase
             {
                 public abstract ActionResult<TResponse> Handle();

--- a/src/Ardalis.ApiEndpoints/FluentGenerics/EndpointBaseSync.cs
+++ b/src/Ardalis.ApiEndpoints/FluentGenerics/EndpointBaseSync.cs
@@ -9,12 +9,12 @@ namespace Ardalis.ApiEndpoints
     {
         public static class WithRequest<TRequest>
         {
-            public abstract class WithResponse<TResponse> : EndpointBase
+            public abstract class WithActionResult<TResponse> : EndpointBase
             {
                 public abstract ActionResult<TResponse> Handle(TRequest request);
             }
 
-            public abstract class WithoutResponse : EndpointBase
+            public abstract class WithActionResult : EndpointBase
             {
                 public abstract ActionResult Handle(TRequest request);
             }
@@ -22,12 +22,12 @@ namespace Ardalis.ApiEndpoints
 
         public static class WithoutRequest
         {
-            public abstract class WithResponse<TResponse> : EndpointBase
+            public abstract class WithActionResult<TResponse> : EndpointBase
             {
                 public abstract ActionResult<TResponse> Handle();
             }
 
-            public abstract class WithoutResponse : EndpointBase
+            public abstract class WithActionResult : EndpointBase
             {
                 public abstract ActionResult Handle();
             }

--- a/tests/Ardalis.ApiEndpoints.CodeAnalyzers.Test/Ardalis.ApiEndpoints.CodeAnalyzers.Test.csproj
+++ b/tests/Ardalis.ApiEndpoints.CodeAnalyzers.Test/Ardalis.ApiEndpoints.CodeAnalyzers.Test.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
   </ItemGroup>


### PR DESCRIPTION
Fixes: #126 

- Added two new `WithResult` methods and renamed old ones
- Updated NuGets
- Added `CreatedAtRoute` sample to address #105

![image](https://user-images.githubusercontent.com/6609929/130650523-0b00a01f-6e0c-4147-85c7-8157a3a64fd3.png)
