### PR TITLE
Feature/template

### DIFF
--- a/.github/workflows/publish-template.yml
+++ b/.github/workflows/publish-template.yml
@@ -1,0 +1,28 @@
+name: publish template package to nuget
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main # Your default release branch
+jobs:
+  build-test-prep-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+        env:
+          DOTNET_INSTALL_DIR: /usr/share/dotnet
+      - name: build and test
+        run: |
+          dotnet restore
+          dotnet build -c Release --no-restore
+          dotnet test -c Release --no-build
+      - name: Create the package
+        run: dotnet pack Sample/Sample.WeatherForecast/templatepack.csproj -c Release --output nupkgs
+      - name: Publish the package to NuGet.org
+        env:
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+        run: dotnet nuget push nupkgs/*.nupkg -k $NUGET_KEY

--- a/Ardalis.ApiEndpoints.sln
+++ b/Ardalis.ApiEndpoints.sln
@@ -37,6 +37,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ardalis.ApiEndpoints.NSwag"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ardalis.ApiEndpoints.Swashbuckle", "src\Ardalis.ApiEndpoints.Swashbuckle\Ardalis.ApiEndpoints.Swashbuckle.csproj", "{0A625FF1-6E6E-445F-B40D-50AE6B5FFCA0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.WeatherForecast", "sample\Sample.WeatherForecast\Sample.WeatherForecast.csproj", "{B37C448C-7DCE-48E2-8CA7-0910CB40393C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -71,6 +73,10 @@ Global
 		{0A625FF1-6E6E-445F-B40D-50AE6B5FFCA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0A625FF1-6E6E-445F-B40D-50AE6B5FFCA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0A625FF1-6E6E-445F-B40D-50AE6B5FFCA0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B37C448C-7DCE-48E2-8CA7-0910CB40393C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B37C448C-7DCE-48E2-8CA7-0910CB40393C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B37C448C-7DCE-48E2-8CA7-0910CB40393C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B37C448C-7DCE-48E2-8CA7-0910CB40393C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -85,6 +91,7 @@ Global
 		{7BBDA78D-3207-479B-9D80-9CADD46C31F1} = {CE4A1E99-D876-4D8F-B56E-9BF453456BAB}
 		{B11A92CB-3AE3-495E-99A2-F06EE62DCDF6} = {7BBDA78D-3207-479B-9D80-9CADD46C31F1}
 		{0A625FF1-6E6E-445F-B40D-50AE6B5FFCA0} = {7BBDA78D-3207-479B-9D80-9CADD46C31F1}
+		{B37C448C-7DCE-48E2-8CA7-0910CB40393C} = {38434103-76E0-4820-B4AF-F5EA5D08A7BD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {932AEB26-7B36-4EFB-B4D1-41F13EDAE5D2}

--- a/sample/Sample.WeatherForecast/.template.config/template.json
+++ b/sample/Sample.WeatherForecast/.template.config/template.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/template",
-  "author": "Ardalis",
+  "author": "Steve Smith @ardalis, Ali zaferany",
 
   "name": "Ardalis.ApiEndpoint Template",
   "description": "A project template for creating an ASP.NET Core application with an example ApiEndpoints for a RESTful HTTP service.",

--- a/sample/Sample.WeatherForecast/.template.config/template.json
+++ b/sample/Sample.WeatherForecast/.template.config/template.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Ardalis",
+
+  "name": "Ardalis.ApiEndpoint Template",
+  "description": "A project template for creating an ASP.NET Core application with an example ApiEndpoints for a RESTful HTTP service.",
+  "identity": "Ardalis.ApiEndpoints.",
+  "shortName": "apiendpoints",
+  "sourceName": "Sample.WeatherForecast",
+  "defaultName": "WebApplication",
+  "preferNameDirectory": true,
+  "classifications": [
+    "Web",
+    "WebAPI",
+    "C#"
+  ],
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sources": [
+    {
+      "source": "./",
+      "target": "./",
+      "exclude": [
+        "README.md",
+        "**/[Bb]in/**",
+        "**/[Oo]bj/**",
+        ".template.config/**/*",
+        ".vs/**/*",
+        "**/*.filelist",
+        "**/*.user",
+        "**/*.lock.json",
+        "**/.git/**",
+        "*.nuspec",
+        "**/node_modules/**",
+        "riderModule.iml" ,
+        "/_ReSharper.Caches/" ,
+        ".idea/" ,
+        "/.idea/" ,
+        ".git/" ,
+        "/.git/" ,
+        "logs/",
+        ".releaserc",
+        "templatepack.csproj"]
+    }
+  ]
+}

--- a/sample/Sample.WeatherForecast/Endpoints/Get.cs
+++ b/sample/Sample.WeatherForecast/Endpoints/Get.cs
@@ -1,0 +1,39 @@
+﻿using Ardalis.ApiEndpoints;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Sample.WeatherForecast.Endpoints;
+
+public class Get : EndpointBaseSync
+  .WithoutRequest
+  .WithActionResult<IEnumerable<WeatherForecast>>
+{
+  private static readonly string[] Summaries = new[]
+  {
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+  };
+
+  private readonly ILogger<Get> _logger;
+
+  public Get(ILogger<Get> logger)
+  {
+    _logger = logger;
+  }
+
+  [HttpGet("/WeatherForecast")]
+  [SwaggerOperation(
+    Summary = "Get weather forecast",
+    OperationId = "WeatherForecast.Get",
+    Tags = new[] { "WeatherForecast" })
+  ]
+  public override ActionResult<IEnumerable<WeatherForecast>> Handle()
+  {
+    return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+                     {
+                       Date = DateTime.Now.AddDays(index),
+                       TemperatureC = Random.Shared.Next(-20, 55),
+                       Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+                     })
+                     .ToArray();
+  }
+}

--- a/sample/Sample.WeatherForecast/Program.cs
+++ b/sample/Sample.WeatherForecast/Program.cs
@@ -1,0 +1,24 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options => options.EnableAnnotations());
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseRouting();
+
+app.MapControllers();
+
+app.Run();

--- a/sample/Sample.WeatherForecast/Properties/launchSettings.json
+++ b/sample/Sample.WeatherForecast/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:56251",
+      "sslPort": 44385
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5218",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7277;http://localhost:5218",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/sample/Sample.WeatherForecast/Sample.WeatherForecast.csproj
+++ b/sample/Sample.WeatherForecast/Sample.WeatherForecast.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Ardalis.ApiEndpoints" Version="4.0.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.2" />
+    </ItemGroup>
+
+</Project>

--- a/sample/Sample.WeatherForecast/WeatherForecast.cs
+++ b/sample/Sample.WeatherForecast/WeatherForecast.cs
@@ -1,0 +1,12 @@
+namespace Sample.WeatherForecast;
+
+public class WeatherForecast
+{
+  public DateTime Date { get; set; }
+
+  public int TemperatureC { get; set; }
+
+  public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+  public string? Summary { get; set; }
+}

--- a/sample/Sample.WeatherForecast/appsettings.Development.json
+++ b/sample/Sample.WeatherForecast/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/sample/Sample.WeatherForecast/appsettings.json
+++ b/sample/Sample.WeatherForecast/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/sample/Sample.WeatherForecast/templatepack.csproj
+++ b/sample/Sample.WeatherForecast/templatepack.csproj
@@ -4,7 +4,7 @@
         <Version>4.0.1</Version>
         <PackageId>Ardalis.ApiEndpoints</PackageId>
         <Title>Ardalis.ApiEndpoint</Title>
-        <Authors>Ardalis</Authors>
+        <Authors>Steve Smith @ardalis, Ali zaferany</Authors>
         <Description>A project template for creating an ASP.NET Core application with an example ApiEndpoints for a RESTful HTTP service.</Description>
         <PackageTags>dotnet-new;dotnet;templates;csharp;api;apiendpoints</PackageTags>
         <TargetFramework>netstandard2.0</TargetFramework>

--- a/sample/Sample.WeatherForecast/templatepack.csproj
+++ b/sample/Sample.WeatherForecast/templatepack.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <PackageType>Template</PackageType>
+        <Version>4.0.1</Version>
+        <PackageId>Ardalis.ApiEndpoints</PackageId>
+        <Title>Ardalis.ApiEndpoint</Title>
+        <Authors>Ardalis</Authors>
+        <Description>A project template for creating an ASP.NET Core application with an example ApiEndpoints for a RESTful HTTP service.</Description>
+        <PackageTags>dotnet-new;dotnet;templates;csharp;api;apiendpoints</PackageTags>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <IncludeContentInPack>true</IncludeContentInPack>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <ContentTargetFolders>content</ContentTargetFolders>
+        <NoWarn>$(NoWarn);NU5128</NoWarn>
+        <NoDefaultExcludes>true</NoDefaultExcludes>
+    </PropertyGroup>
+    <ItemGroup>
+        <Content Include=".\**\*" Exclude=".\**\bin\**;.\**\obj\**;.\.git;.\.git\**;.\.idea;.\.idea\**;**\.vscode\**;**\.github\**;README.md;"/>
+        <Compile Remove="**\*"/>
+    </ItemGroup>
+</Project>


### PR DESCRIPTION
add template base on [#165](https://github.com/ardalis/ApiEndpoints/issues/165)

Modify the [ASP.NET Core Web API / webapi]( https://github.com/dotnet/aspnetcore/tree/main/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp) project template to use API Endpoints instead of controllers

added in samples

Publish it to NuGet via GitHub actions when it changes.(note: for every changes need to update Sample/Sample.WeatherForecast/templatepack.csproj  "Version" )

Let me know if further changes needed 